### PR TITLE
避免 server 假死，支持增量更新 config 文件

### DIFF
--- a/lib/api-creators/getConfigData.js
+++ b/lib/api-creators/getConfigData.js
@@ -29,6 +29,8 @@ module.exports = function (config) {
                 throw new Error('http code=' + httpRes.statusCode);
             }
         } else {
+            // 清除 require 缓存
+            delete require.cache[path.join(cwd, fileName)];
             swagger = require(path.join(cwd, fileName));
         }
     } catch (err) {

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -243,11 +243,10 @@ function openHotReload() {
     var monitorPaths = [mock.swaggerFilePath, mock.configFilePath];
     monitorPaths.forEach((filePath) => {
         if (filePath && fs.existsSync(filePath)) {
-           chokidar.watch(filePath).on('change', (file) => {
+           chokidar.watch(filePath).on('change', _.debounce(function (file) {
                 oneprocess = cp.fork(filePath);
                 mock.server.close();
                 console.log('reload', file)
-                console.log(mock.swaggerFilePath)
                 if (mock.configFilePath && _.includes(mock.swaggerFilePath, file)) {
                     delete require.cache[path.resolve(mock.configFilePath)];
                     var config = require(path.resolve(mock.configFilePath));
@@ -255,7 +254,7 @@ function openHotReload() {
                 } else {
                     reloadServer();
                 }
-            });
+            }, 500));
         }
     });
 }

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -88,6 +88,67 @@ function runMockServer(swaggerFile, port) {
     });
 }
 
+function mockConfig(options) {
+    var configPath = options.config || '';
+    var hasLite = options.lite;
+    var mockFilePath = options.file;
+    var port = options.server;
+    var defaultConfigPath = path.resolve('./mock.config.js');
+    mock.configFilePath = configPath;
+    //默认文件是否存在
+    if (!configPath && !hasLite) {
+        if (!fs.existsSync(defaultConfigPath)) {
+            // 无默认mock.config.js文件
+            inquirer.prompt(createConfigQuestion).then(function(answers) {
+                if (answers.create) {
+                    // 同意自动生成mock.config.js
+                    mock.configFilePath = './mock.config.js';
+                    fs.writeFile(mock.configFilePath, '', (err) => {
+                        if (err) throw err;
+                        createDefaultConfigFile();
+                    });
+                } else {
+                    // 不同意自动生成，需先遍历查找
+                    Finder.from(path.join('..')).findFiles('mock.config.js', function(files) {
+                        if (files.length) {
+                            // 在别的目录下有 mock.config.js 文件
+                            inquirer.prompt(useDefaultQuestion).then(function(answers) {
+                                if (answers.useDefault) {
+                                    // 同意使用该文件作为配置文件
+                                    // 默认路径
+                                    configPath = files[0];
+                                    mock.configFilePath = configPath;
+                                    mockGenByCaseFunc();
+                                } else {
+                                    // 不使用找到的config文件，无config启动
+                                    mock.configFilePath = '';
+                                    runMockServer(mock.swaggerFilePath, mock.options.server);
+                                }
+                            });
+                        } else {
+                            // 不同意生成，且无mock.config.js文件，则无config启动
+                            mock.configFilePath = '';
+                            runMockServer(options.file, options.server);
+                        }
+                    });
+                }
+            });
+        } else {
+            // 找到默认配置文件
+            mock.configFilePath = defaultConfigPath;
+            mockGenByCaseFunc();
+        }
+    } else if (configPath && !hasLite) {
+        // 使用指定的 config 文件
+        mockGenByCaseFunc();
+    } else {
+        // 没有 config 直接起 server
+        mock.configFilePath = '';
+        runMockServer(options.file, options.server);
+    }
+    return configPath;
+}
+
 function mockGenByCaseFunc () {
     var config = require(path.resolve(mock.configFilePath));
     updateConfigFile(config.path, () => {
@@ -111,6 +172,79 @@ function mockGenByCaseFunc () {
             runMockServer(mock.swaggerFilePath, mock.options.server);
         }
     });
+}
+
+function questionAndGen(mockDir) {
+    var mockFileByCasesQuestion = { name: 'mock', message: `是否以${mockDir}文件夹初始化或更新swagger文件的mock数据?`, type: 'confirm', default: true };
+    inquirer.prompt(mockFileByCasesQuestion).then(function(answers) {
+        if (answers.mock) {
+            mockGenByCases(mock.swaggerFilePath, mockDir, function(err) {
+                if (err) throw err;
+                runMockServer(mock.swaggerFilePath, mock.options.server);
+            })
+        } else {
+            runMockServer(mock.swaggerFilePath, mock.options.server);
+        }
+    })
+}
+
+var oneprocess
+
+function openHotReload() {
+    var monitorPaths = [mock.swaggerFilePath, mock.configFilePath];
+    monitorPaths.forEach((filePath) => {
+        if (filePath && fs.existsSync(filePath)) {
+           chokidar.watch(filePath).on('change', _.debounce(function (file) {
+                oneprocess = cp.fork(file);
+                mock.server.close();
+                console.log('reload', file);
+                if (mock.configFilePath && _.includes(mock.swaggerFilePath, file)) {
+                    delete require.cache[path.resolve(mock.configFilePath)];
+                    var config = require(path.resolve(mock.configFilePath));
+                    updateConfigFile(config.path, () => {})
+                } else {
+                    reloadServer();
+                }
+            }, 500));
+        }
+    });
+}
+
+function reloadServer () {
+    runMockServer(mock.file, mock.options.server);
+    console.log('检测到文件变化，已重启Mock Server'.green);
+    if (mock.configFilePath) {oneprocess = newProcess(oneprocess);}
+}
+
+process.on('SIGINT', () => {
+    process.exit(0);
+});
+
+function newProcess (oneprocess) {
+    oneprocess.kill('SIGINT');
+    return cp.fork(mock.configFilePath);
+}
+
+function createDefaultConfigFile() {
+    if (!mock.configFilePath) {
+        console.log('读取默认配置文件路径出错'.red);
+        runMockServer(mock.options.file, mock.options.server);
+    } else {
+        var config = getConfig({ file: mock.swaggerFilePath });
+        if (config && config.swagger && config.swagger.paths) {
+            config.pathObjects = []
+            const paths =_.uniq(_.keys(config.swagger.paths));
+            _.forEach(paths, (path) => {
+                config.pathObjects.push({path: path, value: 0})
+            })
+            juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
+                outPutFile(mock.configFilePath, str, '生成默认配置文件成功!文件位置: ');
+            })
+        } else {
+            console.log('读取swagger文件配置出错'.red);
+            runMockServer(mock.options.file, mock.options.server);
+        }
+    }
 }
 
 function updateConfigFile (paths, cb) {
@@ -159,141 +293,6 @@ function needUpdateConfig (swagger, config) {
         }
     })
     return result;
-}
-
-function questionAndGen(mockDir) {
-    var mockFileByCasesQuestion = { name: 'mock', message: `是否以${mockDir}文件夹初始化或更新swagger文件的mock数据?`, type: 'confirm', default: true };
-    inquirer.prompt(mockFileByCasesQuestion).then(function(answers) {
-        if (answers.mock) {
-            mockGenByCases(mock.swaggerFilePath, mockDir, function(err) {
-                if (err) throw err;
-                runMockServer(mock.swaggerFilePath, mock.options.server);
-            })
-        } else {
-            runMockServer(mock.swaggerFilePath, mock.options.server);
-        }
-    })
-}
-
-function mockConfig(options) {
-    var configPath = options.config || '';
-    var hasLite = options.lite;
-    var mockFilePath = options.file;
-    var port = options.server;
-    var defaultConfigPath = path.resolve('./mock.config.js');
-    mock.configFilePath = configPath;
-    //默认文件是否存在
-    if (!configPath && !hasLite) {
-        if (!fs.existsSync(defaultConfigPath)) {
-            // 无默认mock.config.js文件
-            inquirer.prompt(createConfigQuestion).then(function(answers) {
-                if (answers.create) {
-                    // 同意自动生成mock.config.js
-                    mock.configFilePath = './mock.config.js';
-                    fs.writeFile(mock.configFilePath, '', (err) => {
-                        if (err) throw err;
-                        createDefaultConfigFile();
-                    });
-                } else {
-                    // 不同意自动生成，需先遍历查找
-                    Finder.from(path.join(options.file, '..')).findFiles('mock.config.js', function(files) {
-                        if (files.length) {
-                            // 在别的目录下有 mock.config.js 文件
-                            inquirer.prompt(useDefaultQuestion).then(function(answers) {
-                                if (answers.useDefault) {
-                                    // 同意使用该文件作为配置文件
-                                    // 默认路径
-                                    configPath = files[0];
-                                    mock.configFilePath = configPath;
-                                    mockGenByCaseFunc();
-                                } else {
-                                    // 不使用找到的config文件，无config启动
-                                    mock.configFilePath = '';
-                                    runMockServer(mock.swaggerFilePath, mock.options.server);
-                                }
-                            });
-                        } else {
-                            // 不同意生成，且无mock.config.js文件，则无config启动
-                            mock.configFilePath = '';
-                            runMockServer(options.file, options.server);
-                        }
-                    });
-                }
-            });
-        } else {
-            // 找到默认配置文件
-            mock.configFilePath = defaultConfigPath;
-            mockGenByCaseFunc();
-        }
-    } else if (configPath && !hasLite) {
-        // 使用指定的 config 文件
-        mockGenByCaseFunc();
-    } else {
-        // 没有 config 直接起 server
-        mock.configFilePath = '';
-        runMockServer(options.file, options.server);
-    }
-    return configPath;
-}
-
-// var watcher = chokidar.watch([mock.swaggerFilePath, mock.configFilePath]);
-var oneprocess
-
-function openHotReload() {
-    var monitorPaths = [mock.swaggerFilePath, mock.configFilePath];
-    monitorPaths.forEach((filePath) => {
-        if (filePath && fs.existsSync(filePath)) {
-           chokidar.watch(filePath).on('change', _.debounce(function (file) {
-                oneprocess = cp.fork(filePath);
-                mock.server.close();
-                console.log('reload', file)
-                if (mock.configFilePath && _.includes(mock.swaggerFilePath, file)) {
-                    delete require.cache[path.resolve(mock.configFilePath)];
-                    var config = require(path.resolve(mock.configFilePath));
-                    updateConfigFile(config.path, () => {})
-                } else {
-                    reloadServer();
-                }
-            }, 500));
-        }
-    });
-}
-
-function reloadServer () {
-    runMockServer(mock.file, mock.options.server);
-    console.log('检测到文件变化，已重启Mock Server'.green);
-    oneprocess = newProcess(oneprocess);
-}
-
-process.on('SIGINT', () => {
-    process.exit(0);
-});
-
-function newProcess (oneprocess) {
-    oneprocess.kill('SIGINT');
-    return cp.fork(mock.configFilePath);
-}
-
-function createDefaultConfigFile() {
-    if (!mock.configFilePath) {
-        console.log('读取默认配置文件路径出错'.red);
-        runMockServer(mock.options.file, mock.options.server);
-    } else {
-        var config = getConfig({ file: mock.swaggerFilePath });
-        if (config && config.swagger && config.swagger.paths) {
-            config.pathObjects = []
-            const paths =_.uniq(_.keys(config.swagger.paths));
-            _.forEach(paths, (path) => {
-                config.pathObjects.push({path: path, value: 0})
-            })
-            juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
-                outPutFile(mock.configFilePath, str, '生成默认配置文件成功!文件位置: ');
-            })
-        } else {
-            console.log('读取swagger文件配置出错'.red);
-            runMockServer(mock.options.file, mock.options.server);
-        }
-    }
 }
 
 function outPutFile(filePath, str, message, cb){

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -62,27 +62,103 @@ function create(swaggerFile, options, cb) {
     }
 }
 
+function runMockServer(swaggerFile, port) {
+    var swagger = swaggerFile;
+    var port = isNaN(parseInt(port)) ? 8000 : parseInt(port);
+    // Set the DEBUG environment variable to enable debug output
+    process.env.DEBUG = 'swagger:middleware';
+    var app = express();
+    if (mock.options.file) return;
+    middleware(swagger, app, function(err, middleware) {
+        app.use(
+            middleware.metadata(),
+            middleware.CORS(),
+            middleware.files(),
+            // middleware.validateRequest(),
+            apiCasesMiddleware(mock.configFilePath),
+            proxyMiddleware(mock.configFilePath),
+            middleware.parseRequest(),
+            middleware.mock()
+        );
+
+        mock.server = app.listen(port, function() {
+            openHotReload();
+            console.log('Mock Server 运行在 http://localhost:' + port);
+        });
+    });
+}
+
 function mockGenByCaseFunc () {
     var config = require(path.resolve(mock.configFilePath));
-    if (config.mockDir) {
-        var mockDir = config.mockDir;
-        if (!fs.existsSync(mockDir)) {
-            try {
-                fs.mkdirSync(mockDir);
+    updateConfigFile(config.path, () => {
+        if (config.mockDir) {
+            var mockDir = config.mockDir;
+            if (!fs.existsSync(mockDir)) {
+                try {
+                    fs.mkdirSync(mockDir);
+                    questionAndGen(mockDir);
+                } catch (error) {
+                    console.log('配置文件中的mockDir设置无效'.red);
+                    runMockServer(mock.swaggerFilePath, mock.options.server);
+                    return;
+                }
+            } else {
                 questionAndGen(mockDir);
-            } catch (error) {
-                console.log('配置文件中的mockDir设置无效'.red);
-                runMockServer(mock.swaggerFilePath, mock.options.server);
-                return;
             }
         } else {
-            questionAndGen(mockDir);
+            // no matter what happens
+            // run mock server
+            runMockServer(mock.swaggerFilePath, mock.options.server);
         }
-    } else {
-        // no matter what happens
-        // run mock server
-        runMockServer(mock.swaggerFilePath, mock.options.server);
+    });
+}
+
+function updateConfigFile (paths, cb) {
+    var updateConfigFileQuestion = {
+        name: 'mock',
+        message: `是否增量更新mock config文件？`,
+        type: 'confirm',
+        default: true
     }
+    var config = getConfig({ file: mock.swaggerFilePath });
+    if (config && config.swagger && config.swagger.paths && needUpdateConfig(_.keys(config.swagger.paths), _.keys(paths))) {
+        inquirer.prompt(updateConfigFileQuestion).then(function(answers) {
+            if (answers.mock) {
+                // 增量更新mock config 文件
+                config.pathObjects = [];
+                _.forEach(paths, (value, key) => {
+                    config.pathObjects.push({
+                        path: key,
+                        value: paths[key]
+                    })
+                });
+                _.forEach(config.swagger.paths,((value, key) => {
+                    // 将新增 path 追加到尾部，默认值0，不启用
+                    if (!_.includes(_.keys(paths), key)) {
+                        config.pathObjects.push({path: key, value: 0});
+                    }
+                }))
+                juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
+                    outPutFile(mock.configFilePath, str, '更新配置文件成功', cb);
+                })
+                if (mock.server) { reloadServer(); }
+            } else {
+                cb();
+            }
+        })
+    } else {
+        cb();
+    }
+}
+
+function needUpdateConfig (swagger, config) {
+    let result = false;
+    _.forEach((swagger), (item) => {
+        if (!_.includes(config, item)) {
+            result = true;
+        }
+    })
+    return result;
 }
 
 function questionAndGen(mockDir) {
@@ -109,27 +185,36 @@ function mockConfig(options) {
     //默认文件是否存在
     if (!configPath && !hasLite) {
         if (!fs.existsSync(defaultConfigPath)) {
+            // 无默认mock.config.js文件
             inquirer.prompt(createConfigQuestion).then(function(answers) {
                 if (answers.create) {
+                    // 同意自动生成mock.config.js
                     mock.configFilePath = './mock.config.js';
                     fs.writeFile(mock.configFilePath, '', (err) => {
                         if (err) throw err;
                         createDefaultConfigFile();
                     });
                 } else {
+                    // 不同意自动生成，需先遍历查找
                     Finder.from(path.join(options.file, '..')).findFiles('mock.config.js', function(files) {
                         if (files.length) {
+                            // 在别的目录下有 mock.config.js 文件
                             inquirer.prompt(useDefaultQuestion).then(function(answers) {
                                 if (answers.useDefault) {
+                                    // 同意使用该文件作为配置文件
                                     // 默认路径
                                     configPath = files[0];
                                     mock.configFilePath = configPath;
                                     mockGenByCaseFunc();
                                 } else {
+                                    // 不使用找到的config文件，无config启动
+                                    mock.configFilePath = '';
                                     runMockServer(mock.swaggerFilePath, mock.options.server);
                                 }
                             });
                         } else {
+                            // 不同意生成，且无mock.config.js文件，则无config启动
+                            mock.configFilePath = '';
                             runMockServer(options.file, options.server);
                         }
                     });
@@ -141,56 +226,44 @@ function mockConfig(options) {
             mockGenByCaseFunc();
         }
     } else if (configPath && !hasLite) {
+        // 使用指定的 config 文件
         mockGenByCaseFunc();
     } else {
+        // 没有 config 直接起 server
+        mock.configFilePath = '';
         runMockServer(options.file, options.server);
     }
     return configPath;
 }
 
-function runMockServer(swaggerFile, port) {
-    var swagger = swaggerFile;
-    var port = isNaN(parseInt(port)) ? 8000 : parseInt(port);
-    // Set the DEBUG environment variable to enable debug output
-    process.env.DEBUG = 'swagger:middleware';
-    var app = express();
-    if (mock.options.file) return;
-    middleware(swagger, app, function(err, middleware) {
-        app.use(
-            middleware.metadata(),
-            middleware.CORS(),
-            middleware.files(),
-            // middleware.validateRequest(),
-            apiCasesMiddleware(mock.configFilePath),
-            proxyMiddleware(mock.configFilePath),
-            middleware.parseRequest(),
-            middleware.mock()
-        );
-
-        mock.server = app.listen(port, function() {
-            openHotReload();
-            console.log('Mock Server 运行在 http://localhost:' + port);
-        });
-    });
-}
-var watcher = chokidar.watch([mock.swaggerFilePath, mock.configFilePath]);
+// var watcher = chokidar.watch([mock.swaggerFilePath, mock.configFilePath]);
 var oneprocess
+
 function openHotReload() {
-    var paths = [mock.swaggerFilePath, mock.configFilePath];
-    paths.forEach((path) => {
-        if (path && fs.existsSync(path)) {
-            oneprocess = cp.fork(mock.configFilePath);
-            watcher.on('change', (event, path) => {
+    var monitorPaths = [mock.swaggerFilePath, mock.configFilePath];
+    monitorPaths.forEach((filePath) => {
+        if (filePath && fs.existsSync(filePath)) {
+           chokidar.watch(filePath).on('change', (file) => {
+                oneprocess = cp.fork(filePath);
                 mock.server.close();
-                mockConfig(mock.options);
-                console.log('reload', mock.file)
-                runMockServer(mock.file, mock.options.server);
-                console.log('检测到文件变化，已重启Mock Server'.green);
-                oneprocess = newProcess(oneprocess);
+                console.log('reload', file)
+                console.log(mock.swaggerFilePath)
+                if (mock.configFilePath && _.includes(mock.swaggerFilePath, file)) {
+                    delete require.cache[path.resolve(mock.configFilePath)];
+                    var config = require(path.resolve(mock.configFilePath));
+                    updateConfigFile(config.path, () => {})
+                } else {
+                    reloadServer();
+                }
             });
-            watcher.close()
         }
     });
+}
+
+function reloadServer () {
+    runMockServer(mock.file, mock.options.server);
+    console.log('检测到文件变化，已重启Mock Server'.green);
+    oneprocess = newProcess(oneprocess);
 }
 
 process.on('SIGINT', () => {
@@ -209,9 +282,13 @@ function createDefaultConfigFile() {
     } else {
         var config = getConfig({ file: mock.swaggerFilePath });
         if (config && config.swagger && config.swagger.paths) {
-            config.paths = _.uniq(_.keys(config.swagger.paths))
+            config.pathObjects = []
+            const paths =_.uniq(_.keys(config.swagger.paths));
+            _.forEach(paths, (path) => {
+                config.pathObjects.push({path: path, value: 0})
+            })
             juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
-                outPutFile(mock.configFilePath, str);
+                outPutFile(mock.configFilePath, str, '生成默认配置文件成功!文件位置: ');
             })
         } else {
             console.log('读取swagger文件配置出错'.red);
@@ -220,12 +297,16 @@ function createDefaultConfigFile() {
     }
 }
 
-function outPutFile(filePath, str) {
+function outPutFile(filePath, str, message, cb){
     fs.outputFile(filePath, str, function(err) {
         if (err) {
             throw err;
         }
-        console.log(('生成默认配置文件成功!文件位置: ' + filePath).green);
-        mockGenByCaseFunc(mock.options.file, mock.options.server);
+        console.log((message + filePath).green);
+        if (cb) {
+            cb();
+        } else {
+            mockGenByCaseFunc(mock.options.file, mock.options.server)
+        }
     })
 }

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs-extra');
+var cp = require('child_process');
 var colors = require('colors');
 var mockGenByCases = require('swagger-mock-file-generator-by-cases');
 var mockGen = require('swagger-mock-file-generator');
@@ -172,18 +173,33 @@ function runMockServer(swaggerFile, port) {
         });
     });
 }
-
+var watcher = chokidar.watch([mock.swaggerFilePath, mock.configFilePath]);
+var oneprocess
 function openHotReload() {
     var paths = [mock.swaggerFilePath, mock.configFilePath];
     paths.forEach((path) => {
         if (path && fs.existsSync(path)) {
-            chokidar.watch(path).on('change', (event, path) => {
+            oneprocess = cp.fork(mock.configFilePath);
+            watcher.on('change', (event, path) => {
                 mock.server.close();
-                runMockServer(mock.options.file, mock.options.server);
+                mockConfig(mock.options);
+                console.log('reload', mock.file)
+                runMockServer(mock.file, mock.options.server);
                 console.log('检测到文件变化，已重启Mock Server'.green);
+                oneprocess = newProcess(oneprocess);
             });
+            watcher.close()
         }
     });
+}
+
+process.on('SIGINT', () => {
+    process.exit(0);
+});
+
+function newProcess (oneprocess) {
+    oneprocess.kill('SIGINT');
+    return cp.fork(mock.configFilePath);
 }
 
 function createDefaultConfigFile() {

--- a/templates/mock/config-template.juicer
+++ b/templates/mock/config-template.juicer
@@ -2,8 +2,8 @@ module.exports = {
   mockDir: './mock/',
   basePath: '$${swagger.basePath}',
   path: {
-    {@each paths as path,index}
-    '$${path}': 0,
+    {@each pathObjects as path,index}
+    '$${path.path}': $${path.value},
     {@/each}
   },
   proxy: {}


### PR DESCRIPTION
**Need Review**

**Need Test**

- 为 https://github.com/lincolnlau/swagger-jsblade/issues/13 支持 hot reload 时增量更新 config 文件
- 为 https://github.com/lincolnlau/swagger-jsblade/issues/9 避免 server 因频繁修改 swagger 和 config 文件时假死，开启子进程并设置 debounce 双保险