### PR TITLE
Mock功能支持多个 swagger 文件传入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ temp
 npm-debug.log
 mock.config.js
 mock.json
+swagger/*

--- a/bin/blade.js
+++ b/bin/blade.js
@@ -11,7 +11,9 @@ var frameworks = Object.keys(project.frameworks).join('|');
 var cli = require('../lib/util/cli');
 var execute = cli.execute;
 var appInfo = require('./../package.json');
-
+function list(val) {
+    return val.split(',');
+}
 app
     .version(appInfo.version);
 
@@ -50,6 +52,7 @@ app
     .option('-s, --server [portNum]', "启动mock server,端口号,默认8000")
     .option('-c, --config <filePath>', "mock数据配置文件")
     .option('-l, --lite', "不自动识别config文件")
+    .option('-i, --include <items>', "多swagger文件path合并到mock.config.js", list)
     .action(execute(mock.create));
 
 app.parse(process.argv);

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -185,12 +185,12 @@ function mockConfig(options) {
 function fileMergeConfig (pathList, cb) {
     var existPath = [];
     var uniqPath;
-    var pathKey; //接口path
+    var pathKey; // 用于存储定义文件配置对象的变量
     // 读取 includes 传入文件的 swagger 定义
     var config = getConfig({ file: mock.swaggerFilePath });
     // 将主文件与 includes 进来的文件一起遍历
     var swaggerFilesPaths = pathList.concat(mock.swaggerFilePath);
-    //筛选存在的path
+    // 筛选存在的path
     swaggerFilesPaths.forEach((path) => {
         if (fs.existsSync(path)) {
             pathKey = getConfig({ file: path });
@@ -357,20 +357,18 @@ function updateConfigFile (configPaths, cb) {
             if (answers.updateConfig) {
                 resetConfigFile(_.keys(config.swagger.paths), config, cb);
             } else {
-                cb();
+                if (cb) cb();
             }
         })
     } else {
-        cb();
+        if (cb) cb();
     }
 }
 
 function needUpdateConfig (swagger, config) {
-    let result = false;
-    result = _.some(swagger, (item) => {
+    return _.some(swagger, (item) => {
         return !_.includes(config, item)
     })
-    return result;
 }
 
 function outPutFile(filePath, str, message, cb){

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -27,8 +27,24 @@ var mock = {
     options: '',
     cb: null
 };
-var createConfigQuestion = { name: 'create', message: '是否需要生成默认配置文件?', type: 'confirm', default: true };
-var useDefaultQuestion = { name: 'useDefault', message: '是否需要使用默认配置文件?', type: 'confirm', default: true };
+var createConfigQuestion = {
+    name: 'create',
+    message: '是否需要生成默认配置文件?',
+    type: 'confirm',
+    default: true
+};
+var useDefaultQuestion = {
+    name: 'useDefault',
+    message: '是否需要使用默认配置文件?',
+    type: 'confirm',
+    default: true
+};
+var updateConfigFileQuestion = {
+    name: 'updateConfig',
+    message: `是否增量更新mock config文件？`,
+    type: 'confirm',
+    default: true
+};
 
 function create(swaggerFile, options, cb) {
     mock.swaggerFilePath = swaggerFile;
@@ -167,47 +183,63 @@ function mockConfig(options) {
     return configPath;
 }
 function fileMergeConfig (pathList, cb) {
-    let existPath = [];
-    let uniqPath;
-    let pathKey; //接口path
-    let config = getConfig({ file: mock.swaggerFilePath });
+    var existPath = [];
+    var uniqPath;
+    var pathKey; //接口path
+    // 读取 includes 传入文件的 swagger 定义
+    var config = getConfig({ file: mock.swaggerFilePath });
+    // 将主文件与 includes 进来的文件一起遍历
+    var swaggerFilesPaths = pathList.concat(mock.swaggerFilePath);
     //筛选存在的path
-    pathList.forEach((path) => {
+    swaggerFilesPaths.forEach((path) => {
         if (fs.existsSync(path)) {
             pathKey = getConfig({ file: path });
             if (pathKey.swagger && pathKey.swagger.paths) {
-                uniqPath = _.uniq(_.keys(pathKey.swagger.paths));
-                existPath = existPath.length ? existPath.concat(uniqPath) : uniqPath;
+                existPath = existPath.concat(_.keys(pathKey.swagger.paths));
             }
+        } else {
+            console.log(`未找到${path}文件，读取该文件定义失败`.red);
         }
     });
-    if (existPath.length > 0) {
-        resetConfigFile(existPath, config, cb);
+    // 将去重过的 paths 数组传入 resetConfigFile 函数去更新配置文件
+    if (_.uniq(existPath).length > 0) {
+        inquirer.prompt(updateConfigFileQuestion).then(function(answers) {
+            if (answers.updateConfig) {
+                resetConfigFile(_.uniq(existPath), config, cb);
+            } else {
+                cb();
+            }
+        })
     }
 }
 function mockGenByCaseFunc () {
     var config = require(path.resolve(mock.configFilePath));
-    updateConfigFile(config.path, () => {
-        if (config.mockDir) {
-            var mockDir = config.mockDir;
-            if (!fs.existsSync(mockDir)) {
-                try {
-                    fs.mkdirSync(mockDir);
-                    questionAndGen(mockDir);
-                } catch (error) {
-                    console.log('配置文件中的mockDir设置无效'.red);
-                    runMockServer(mock.swaggerFilePath, mock.options.server);
-                    return;
-                }
-            } else {
+    if (mock.options.include) {
+        mockGenByCaseCb(config)
+    } else {
+        updateConfigFile(config.path, mockGenByCaseCb(config));
+    }
+}
+function mockGenByCaseCb (config) {
+    if (config.mockDir) {
+        var mockDir = config.mockDir;
+        if (!fs.existsSync(mockDir)) {
+            try {
+                fs.mkdirSync(mockDir);
                 questionAndGen(mockDir);
+            } catch (error) {
+                console.log('配置文件中的mockDir设置无效'.red);
+                runMockServer(mock.swaggerFilePath, mock.options.server);
+                return;
             }
         } else {
-            // no matter what happens
-            // run mock server
-            runMockServer(mock.swaggerFilePath, mock.options.server);
+            questionAndGen(mockDir);
         }
-    });
+    } else {
+        // no matter what happens
+        // run mock server
+        runMockServer(mock.swaggerFilePath, mock.options.server);
+    }
 }
 
 function questionAndGen(mockDir) {
@@ -283,37 +315,43 @@ function createDefaultConfigFile() {
     }
 }
 function resetConfigFile (paths, config, cb) {
-    // 增量更新mock config 文件
+    // 增量更新 mock config 文件函数
+    // 先读取当前 config 文件中已有的配置
+    var configFileObj = require(path.resolve(mock.configFilePath));
+    var configFilePaths = configFileObj ? configFileObj.path : {} ;
+    // 避免覆盖了已经写好的同名配置
     config.pathObjects = [];
-    // _.forEach(paths, (value, key) => {
-    //     config.pathObjects.push({
-    //         path: key,
-    //         value: paths[key]
-    //     })
-    // });
-    _.forEach(paths,((value, key) => {
-        // 将新增 path 追加到尾部，默认值0，不启用
-        if (!_.includes(_.keys(paths), key)) {
-            config.pathObjects.push({path: value, value: 0});
-        }
-    }))
-    juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
-        outPutFile(mock.configFilePath, str, '更新配置文件成功', cb);
+    _.forEach(configFilePaths, (value, key) => {
+        config.pathObjects.push({
+            path: key,
+            value: value
+        })
     })
-    if (mock.server) { reloadServer(); }
-}
-function updateConfigFile (paths, cb) {
-    var updateConfigFileQuestion = {
-        name: 'mock',
-        message: `是否增量更新mock config文件？`,
-        type: 'confirm',
-        default: true
+    var newPaths = [];
+    if (config && config.swagger && config.swagger.paths) {
+        _.forEach(paths,((value) => {
+            // 将新增 path 追加到尾部，默认值0，不启用
+            if (value && !_.includes(_.keys(configFilePaths), value)) {
+                newPaths.push(value);
+                config.pathObjects.push({path: value, value: 0});
+            }
+        }))
+        juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
+            outPutFile(mock.configFilePath, str, '更新配置文件成功', cb);
+            if (newPaths.length) {
+                console.log('本次增量更新的接口定义：'.green);
+                newPaths.forEach((path) => console.log(`${path}`.green));
+            }
+        })
+        if (mock.server) { reloadServer(); }
     }
+}
+function updateConfigFile (configPaths, cb) {
     var config = getConfig({ file: mock.swaggerFilePath });
-    if (config && config.swagger && config.swagger.paths && needUpdateConfig(_.keys(config.swagger.paths), _.keys(paths))) {
+    if (config && config.swagger && config.swagger.paths && needUpdateConfig(_.keys(config.swagger.paths), _.keys(configPaths))) {
         inquirer.prompt(updateConfigFileQuestion).then(function(answers) {
-            if (answers.mock) {
-                resetConfigFile(paths, config, cb);
+            if (answers.updateConfig) {
+                resetConfigFile(_.keys(config.swagger.paths), config, cb);
             } else {
                 cb();
             }
@@ -325,10 +363,8 @@ function updateConfigFile (paths, cb) {
 
 function needUpdateConfig (swagger, config) {
     let result = false;
-    _.forEach((swagger), (item) => {
-        if (!_.includes(config, item)) {
-            result = true;
-        }
+    result = _.some(swagger, (item) => {
+        return !_.includes(config, item)
     })
     return result;
 }

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -246,7 +246,11 @@ function questionAndGen(mockDir) {
     var mockFileByCasesQuestion = { name: 'mock', message: `是否以${mockDir}文件夹初始化或更新swagger文件的mock数据?`, type: 'confirm', default: true };
     inquirer.prompt(mockFileByCasesQuestion).then(function(answers) {
         if (answers.mock) {
-            mockGenByCases(mock.swaggerFilePath, mockDir, function(err) {
+            var paths = [mock.swaggerFilePath];
+            if (mock.options.include) {
+                paths = paths.concat(mock.options.include);
+            }
+            mockGenByCases(paths, mockDir, function(err) {
                 if (err) throw err;
                 runMockServer(mock.swaggerFilePath, mock.options.server);
             })

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -94,6 +94,7 @@ function mockConfig(options) {
     var hasLite = options.lite;
     var mockFilePath = options.file;
     var port = options.server;
+    var hasInclude = options.include;
     var defaultConfigPath = path.resolve('./mock.config.js');
     mock.configFilePath = configPath;
     //默认文件是否存在
@@ -107,6 +108,9 @@ function mockConfig(options) {
                     fs.writeFile(mock.configFilePath, '', (err) => {
                         if (err) throw err;
                         createDefaultConfigFile();
+                        if (hasInclude) {
+                            fileMergeConfig(options.include); //多swagger文件合并到config
+                        }
                     });
                 } else {
                     // 不同意自动生成，需先遍历查找
@@ -119,7 +123,12 @@ function mockConfig(options) {
                                     // 默认路径
                                     configPath = files[0];
                                     mock.configFilePath = configPath;
-                                    mockGenByCaseFunc();
+                                    if (hasInclude) {
+                                        fileMergeConfig(options.include, mockGenByCaseFunc); //多swagger文件合并到config
+                                    } else {
+                                        mockGenByCaseFunc();
+                                    }
+
                                 } else {
                                     // 不使用找到的config文件，无config启动
                                     mock.configFilePath = '';
@@ -137,11 +146,19 @@ function mockConfig(options) {
         } else {
             // 找到默认配置文件
             mock.configFilePath = defaultConfigPath;
-            mockGenByCaseFunc();
+            if (hasInclude) {
+                fileMergeConfig(options.include, mockGenByCaseFunc); //多swagger文件合并到config
+            } else {
+                mockGenByCaseFunc();
+            }
         }
     } else if (configPath && !hasLite) {
         // 使用指定的 config 文件
-        mockGenByCaseFunc();
+        if (hasInclude) {
+            fileMergeConfig(options.include, mockGenByCaseFunc); //多swagger文件合并到config
+        } else {
+            mockGenByCaseFunc();
+        }
     } else {
         // 没有 config 直接起 server
         mock.configFilePath = '';
@@ -149,7 +166,25 @@ function mockConfig(options) {
     }
     return configPath;
 }
-
+function fileMergeConfig (pathList, cb) {
+    let existPath = [];
+    let uniqPath;
+    let pathKey; //接口path
+    let config = getConfig({ file: mock.swaggerFilePath });
+    //筛选存在的path
+    pathList.forEach((path) => {
+        if (fs.existsSync(path)) {
+            pathKey = getConfig({ file: path });
+            if (pathKey.swagger && pathKey.swagger.paths) {
+                uniqPath = _.uniq(_.keys(pathKey.swagger.paths));
+                existPath = existPath.length ? existPath.concat(uniqPath) : uniqPath;
+            }
+        }
+    });
+    if (existPath.length > 0) {
+        resetConfigFile(existPath, config, cb);
+    }
+}
 function mockGenByCaseFunc () {
     var config = require(path.resolve(mock.configFilePath));
     updateConfigFile(config.path, () => {
@@ -247,7 +282,26 @@ function createDefaultConfigFile() {
         }
     }
 }
-
+function resetConfigFile (paths, config, cb) {
+    // 增量更新mock config 文件
+    config.pathObjects = [];
+    // _.forEach(paths, (value, key) => {
+    //     config.pathObjects.push({
+    //         path: key,
+    //         value: paths[key]
+    //     })
+    // });
+    _.forEach(paths,((value, key) => {
+        // 将新增 path 追加到尾部，默认值0，不启用
+        if (!_.includes(_.keys(paths), key)) {
+            config.pathObjects.push({path: value, value: 0});
+        }
+    }))
+    juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
+        outPutFile(mock.configFilePath, str, '更新配置文件成功', cb);
+    })
+    if (mock.server) { reloadServer(); }
+}
 function updateConfigFile (paths, cb) {
     var updateConfigFileQuestion = {
         name: 'mock',
@@ -259,24 +313,7 @@ function updateConfigFile (paths, cb) {
     if (config && config.swagger && config.swagger.paths && needUpdateConfig(_.keys(config.swagger.paths), _.keys(paths))) {
         inquirer.prompt(updateConfigFileQuestion).then(function(answers) {
             if (answers.mock) {
-                // 增量更新mock config 文件
-                config.pathObjects = [];
-                _.forEach(paths, (value, key) => {
-                    config.pathObjects.push({
-                        path: key,
-                        value: paths[key]
-                    })
-                });
-                _.forEach(config.swagger.paths,((value, key) => {
-                    // 将新增 path 追加到尾部，默认值0，不启用
-                    if (!_.includes(_.keys(paths), key)) {
-                        config.pathObjects.push({path: key, value: 0});
-                    }
-                }))
-                juicerAdapter(path.join(__dirname, '../../templates/mock/config-template.juicer'), config, function(err, str) {
-                    outPutFile(mock.configFilePath, str, '更新配置文件成功', cb);
-                })
-                if (mock.server) { reloadServer(); }
+                resetConfigFile(paths, config, cb);
             } else {
                 cb();
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,30 @@
 {
   "name": "swagger-jsblade",
-  "version": "0.1.20",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "dependencies": {
+    "accepts": {
+      "version": "1.3.4",
+      "resolved": "http://r.npm.sankuai.com/accepts/download/accepts-1.3.4.tgz",
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "dependencies": {
+        "mime-db": {
+          "version": "1.30.0",
+          "resolved": "http://r.npm.sankuai.com/mime-db/download/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "http://r.npm.sankuai.com/mime-types/download/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.2.2",
+      "resolved": "http://r.npm.sankuai.com/ajv/download/ajv-5.2.2.tgz",
+      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk="
+    },
     "anymatch": {
       "version": "1.3.0",
       "resolved": "http://r.npm.sankuai.com/anymatch/download/anymatch-1.3.0.tgz",
@@ -33,6 +55,11 @@
       "resolved": "http://r.npm.sankuai.com/arr-flatten/download/arr-flatten-1.0.3.tgz",
       "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E="
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "http://r.npm.sankuai.com/array-flatten/download/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "http://r.npm.sankuai.com/array-unique/download/array-unique-0.2.1.tgz",
@@ -43,6 +70,21 @@
       "resolved": "http://r.npm.sankuai.com/arrify/download/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "http://r.npm.sankuai.com/asn1/download/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/assert-plus/download/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "http://r.npm.sankuai.com/assertion-error/download/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+    },
     "async": {
       "version": "0.2.6",
       "resolved": "http://r.npm.sankuai.com/async/download/async-0.2.6.tgz",
@@ -52,6 +94,21 @@
       "version": "1.0.1",
       "resolved": "http://r.npm.sankuai.com/async-each/download/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "http://r.npm.sankuai.com/asynckit/download/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "http://r.npm.sankuai.com/aws-sign2/download/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "http://r.npm.sankuai.com/aws4/download/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-polyfill": {
       "version": "6.23.0",
@@ -67,6 +124,12 @@
       "version": "0.4.2",
       "resolved": "http://r.npm.sankuai.com/balanced-match/download/balanced-match-0.4.2.tgz",
       "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "http://r.npm.sankuai.com/bcrypt-pbkdf/download/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true
     },
     "binary-extensions": {
       "version": "1.8.0",
@@ -85,6 +148,18 @@
         }
       }
     },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "http://r.npm.sankuai.com/boom/download/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "http://r.npm.sankuai.com/hoek/download/hoek-4.2.0.tgz",
+          "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "http://r.npm.sankuai.com/brace-expansion/download/brace-expansion-1.1.7.tgz",
@@ -94,6 +169,11 @@
       "version": "1.8.5",
       "resolved": "http://r.npm.sankuai.com/braces/download/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "http://r.npm.sankuai.com/browser-stdout/download/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "busboy": {
       "version": "0.2.14",
@@ -127,20 +207,45 @@
       "resolved": "http://r.npm.sankuai.com/call-me-maybe/download/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "http://r.npm.sankuai.com/caseless/download/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "http://r.npm.sankuai.com/chai/download/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw="
+    },
     "chance": {
       "version": "0.7.7",
       "resolved": "http://r.npm.sankuai.com/chance/download/chance-0.7.7.tgz",
       "integrity": "sha1-ztrmy2uPqmzl9jWp+mT+ozO12pk="
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "http://r.npm.sankuai.com/check-error/download/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "http://r.npm.sankuai.com/chokidar/download/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg="
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "http://r.npm.sankuai.com/co/download/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "http://r.npm.sankuai.com/combined-stream/download/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
     },
     "commander": {
       "version": "2.9.0",
@@ -154,10 +259,20 @@
         }
       }
     },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "http://r.npm.sankuai.com/component-emitter/download/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "http://r.npm.sankuai.com/concat-map/download/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "http://r.npm.sankuai.com/content-disposition/download/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.2",
@@ -179,6 +294,11 @@
       "resolved": "http://r.npm.sankuai.com/cookie-signature/download/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "http://r.npm.sankuai.com/cookiejar/download/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+    },
     "core-js": {
       "version": "2.4.1",
       "resolved": "http://r.npm.sankuai.com/core-js/download/core-js-2.4.1.tgz",
@@ -188,6 +308,28 @@
       "version": "1.0.2",
       "resolved": "http://r.npm.sankuai.com/core-util-is/download/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "http://r.npm.sankuai.com/cryptiles/download/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "http://r.npm.sankuai.com/boom/download/boom-5.2.0.tgz",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI="
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "http://r.npm.sankuai.com/hoek/download/hoek-4.2.0.tgz",
+          "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "http://r.npm.sankuai.com/dashdash/download/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA="
     },
     "debug": {
       "version": "2.2.0",
@@ -201,10 +343,25 @@
         }
       }
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "http://r.npm.sankuai.com/deep-eql/download/deep-eql-3.0.1.tgz",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/delayed-stream/download/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "depd": {
       "version": "1.1.0",
       "resolved": "http://r.npm.sankuai.com/depd/download/depd-1.1.0.tgz",
       "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "http://r.npm.sankuai.com/destroy/download/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "dicer": {
       "version": "0.2.5",
@@ -228,30 +385,66 @@
         }
       }
     },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "http://r.npm.sankuai.com/diff/download/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+    },
     "discontinuous-range": {
       "version": "1.0.0",
       "resolved": "http://r.npm.sankuai.com/discontinuous-range/download/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "http://r.npm.sankuai.com/ecc-jsbn/download/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "http://r.npm.sankuai.com/ee-first/download/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "http://r.npm.sankuai.com/encodeurl/download/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "http://r.npm.sankuai.com/es6-promise/download/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "http://r.npm.sankuai.com/escape-html/download/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-regexp": {
       "version": "0.0.1",
       "resolved": "http://r.npm.sankuai.com/escape-regexp/download/escape-regexp-0.0.1.tgz",
       "integrity": "sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://r.npm.sankuai.com/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "http://r.npm.sankuai.com/esprima/download/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+      "version": "4.0.0",
+      "resolved": "http://r.npm.sankuai.com/esprima/download/esprima-4.0.0.tgz",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "http://r.npm.sankuai.com/etag/download/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "http://r.npm.sankuai.com/eventemitter3/download/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
     },
     "events": {
       "version": "1.1.0",
@@ -508,10 +701,52 @@
         }
       }
     },
+    "express-proxy-middleware": {
+      "version": "1.0.8",
+      "resolved": "http://r.npm.sankuai.com/express-proxy-middleware/download/express-proxy-middleware-1.0.8.tgz",
+      "integrity": "sha1-3GHSdvu7kdOzXbo201w+wUMzn/Q=",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "http://r.npm.sankuai.com/debug/download/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+        },
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "http://r.npm.sankuai.com/depd/download/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        },
+        "express": {
+          "version": "4.15.4",
+          "resolved": "http://r.npm.sankuai.com/express/download/express-4.15.4.tgz",
+          "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE="
+        },
+        "qs": {
+          "version": "6.5.0",
+          "resolved": "http://r.npm.sankuai.com/qs/download/qs-6.5.0.tgz",
+          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "http://r.npm.sankuai.com/extend/download/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "http://r.npm.sankuai.com/extglob/download/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "http://r.npm.sankuai.com/extsprintf/download/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/fast-deep-equal/download/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -523,6 +758,18 @@
       "resolved": "http://r.npm.sankuai.com/fill-range/download/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM="
     },
+    "finalhandler": {
+      "version": "1.0.5",
+      "resolved": "http://r.npm.sankuai.com/finalhandler/download/finalhandler-1.0.5.tgz",
+      "integrity": "sha1-pwEwPSV6G8gv6lR6M+WuiVMXI98=",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "http://r.npm.sankuai.com/debug/download/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "http://r.npm.sankuai.com/for-in/download/for-in-1.0.2.tgz",
@@ -532,6 +779,36 @@
       "version": "0.1.5",
       "resolved": "http://r.npm.sankuai.com/for-own/download/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "http://r.npm.sankuai.com/forever-agent/download/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "http://r.npm.sankuai.com/form-data/download/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8="
+    },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "http://r.npm.sankuai.com/format-util/download/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
+    },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "http://r.npm.sankuai.com/formidable/download/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "http://r.npm.sankuai.com/forwarded/download/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.0",
+      "resolved": "http://r.npm.sankuai.com/fresh/download/fresh-0.5.0.tgz",
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
     },
     "fs-extra": {
       "version": "0.30.0",
@@ -643,6 +920,11 @@
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.1",
@@ -1219,6 +1501,21 @@
         }
       }
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "http://r.npm.sankuai.com/get-func-name/download/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "http://r.npm.sankuai.com/getpass/download/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo="
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "http://r.npm.sankuai.com/glob/download/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
+    },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "http://r.npm.sankuai.com/glob-base/download/glob-base-0.3.0.tgz",
@@ -1233,6 +1530,43 @@
       "version": "http://r.npm.sankuai.com/graceful-fs/download/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "http://r.npm.sankuai.com/growl/download/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "http://r.npm.sankuai.com/har-schema/download/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "http://r.npm.sankuai.com/har-validator/download/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0="
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/has-flag/download/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "http://r.npm.sankuai.com/hawk/download/hawk-6.0.2.tgz",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "http://r.npm.sankuai.com/hoek/download/hoek-4.2.0.tgz",
+          "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+        }
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "http://r.npm.sankuai.com/he/download/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
     "hoek": {
       "version": "2.14.0",
       "resolved": "http://r.npm.sankuai.com/hoek/download/hoek-2.14.0.tgz",
@@ -1243,10 +1577,47 @@
       "resolved": "http://r.npm.sankuai.com/http-errors/download/http-errors-1.6.1.tgz",
       "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc="
     },
+    "http-proxy": {
+      "version": "1.16.2",
+      "resolved": "http://r.npm.sankuai.com/http-proxy/download/http-proxy-1.16.2.tgz",
+      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I="
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.4",
+      "resolved": "http://r.npm.sankuai.com/http-proxy-middleware/download/http-proxy-middleware-0.17.4.tgz",
+      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+      "dependencies": {
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "http://r.npm.sankuai.com/is-extglob/download/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "http://r.npm.sankuai.com/is-glob/download/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo="
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "http://r.npm.sankuai.com/lodash/download/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "http://r.npm.sankuai.com/http-signature/download/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE="
+    },
     "iconv-lite": {
       "version": "0.4.15",
       "resolved": "http://r.npm.sankuai.com/iconv-lite/download/iconv-lite-0.4.15.tgz",
       "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://r.npm.sankuai.com/inflight/download/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
     },
     "inherits": {
       "version": "2.0.3",
@@ -1427,6 +1798,11 @@
         }
       }
     },
+    "ipaddr.js": {
+      "version": "1.4.0",
+      "resolved": "http://r.npm.sankuai.com/ipaddr.js/download/ipaddr.js-1.4.0.tgz",
+      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "http://r.npm.sankuai.com/is-binary-path/download/is-binary-path-1.0.1.tgz",
@@ -1477,6 +1853,11 @@
       "resolved": "http://r.npm.sankuai.com/is-primitive/download/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/is-typedarray/download/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "http://r.npm.sankuai.com/isarray/download/isarray-1.0.0.tgz",
@@ -1487,17 +1868,66 @@
       "resolved": "http://r.npm.sankuai.com/isobject/download/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "http://r.npm.sankuai.com/isstream/download/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "http://r.npm.sankuai.com/js-yaml/download/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY="
+      "version": "3.10.0",
+      "resolved": "http://r.npm.sankuai.com/js-yaml/download/js-yaml-3.10.0.tgz",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "http://r.npm.sankuai.com/jsbn/download/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "http://r.npm.sankuai.com/json-schema/download/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-ref-parser": {
-      "version": "git://github.com/whq731/json-schema-ref-parser.git#67048db0a4624042c479c8520f984c533a6667a0"
+      "version": "1.4.1",
+      "resolved": "http://r.npm.sankuai.com/json-schema-ref-parser/download/json-schema-ref-parser-1.4.1.tgz",
+      "integrity": "sha1-wMLkOL8HlnI7AkUbrovH3Qs3/tA="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "http://r.npm.sankuai.com/json-schema-traverse/download/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "http://r.npm.sankuai.com/json-stable-stringify/download/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "http://r.npm.sankuai.com/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "http://r.npm.sankuai.com/json3/download/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
     "jsonfile": {
-      "version": "http://r.npm.sankuai.com/jsonfile/download/jsonfile-3.0.0.tgz",
-      "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A="
+      "version": "4.0.0",
+      "resolved": "http://r.npm.sankuai.com/jsonfile/download/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "http://r.npm.sankuai.com/jsonify/download/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "http://r.npm.sankuai.com/jsprim/download/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI="
     },
     "juicer-express-adapter": {
       "version": "0.1.10",
@@ -1557,25 +1987,90 @@
       "resolved": "http://r.npm.sankuai.com/lodash/download/lodash-4.13.1.tgz",
       "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
     },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "http://r.npm.sankuai.com/lodash._baseassign/download/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4="
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "http://r.npm.sankuai.com/lodash._basecopy/download/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "http://r.npm.sankuai.com/lodash._basecreate/download/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "http://r.npm.sankuai.com/lodash._getnative/download/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "http://r.npm.sankuai.com/lodash._isiterateecall/download/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "http://r.npm.sankuai.com/lodash.create/download/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "http://r.npm.sankuai.com/lodash.get/download/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "http://r.npm.sankuai.com/lodash.isarguments/download/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "http://r.npm.sankuai.com/lodash.isarray/download/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "http://r.npm.sankuai.com/lodash.isequal/download/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "http://r.npm.sankuai.com/lodash.keys/download/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
+    },
+    "log": {
+      "version": "1.4.0",
+      "resolved": "http://r.npm.sankuai.com/log/download/log-1.4.0.tgz",
+      "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "http://r.npm.sankuai.com/media-typer/download/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "http://r.npm.sankuai.com/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "http://r.npm.sankuai.com/methods/download/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "http://r.npm.sankuai.com/micromatch/download/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "http://r.npm.sankuai.com/mime/download/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
     },
     "mime-db": {
       "version": "1.27.0",
@@ -1606,6 +2101,18 @@
           "version": "0.0.8",
           "resolved": "http://r.npm.sankuai.com/minimist/download/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "http://r.npm.sankuai.com/mocha/download/mocha-3.5.3.tgz",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "http://r.npm.sankuai.com/debug/download/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
         }
       }
     },
@@ -1657,6 +2164,11 @@
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
       "optional": true
     },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "http://r.npm.sankuai.com/negotiator/download/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
     "node-find-files": {
       "version": "0.0.4",
       "resolved": "http://r.npm.sankuai.com/node-find-files/download/node-find-files-0.0.4.tgz",
@@ -1667,6 +2179,11 @@
       "resolved": "http://r.npm.sankuai.com/normalize-path/download/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
     },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "http://r.npm.sankuai.com/oauth-sign/download/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "http://r.npm.sankuai.com/object.omit/download/object.omit-2.0.1.tgz",
@@ -1676,6 +2193,11 @@
       "version": "2.3.0",
       "resolved": "http://r.npm.sankuai.com/on-finished/download/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://r.npm.sankuai.com/once/download/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "ono": {
       "version": "2.2.5",
@@ -1696,6 +2218,11 @@
       "version": "3.0.4",
       "resolved": "http://r.npm.sankuai.com/parse-glob/download/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "http://r.npm.sankuai.com/parseurl/download/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "path": {
       "version": "0.12.7",
@@ -1726,6 +2253,21 @@
       "resolved": "http://r.npm.sankuai.com/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "http://r.npm.sankuai.com/path-to-regexp/download/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "http://r.npm.sankuai.com/pathval/download/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "http://r.npm.sankuai.com/performance-now/download/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "http://r.npm.sankuai.com/preserve/download/preserve-0.2.0.tgz",
@@ -1735,6 +2277,16 @@
       "version": "1.0.7",
       "resolved": "http://r.npm.sankuai.com/process-nextick-args/download/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "proxy-addr": {
+      "version": "1.1.5",
+      "resolved": "http://r.npm.sankuai.com/proxy-addr/download/proxy-addr-1.1.5.tgz",
+      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "http://r.npm.sankuai.com/punycode/download/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
       "version": "1.0.1",
@@ -1755,6 +2307,11 @@
       "version": "1.1.6",
       "resolved": "http://r.npm.sankuai.com/randomatic/download/randomatic-1.1.6.tgz",
       "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "http://r.npm.sankuai.com/range-parser/download/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.2.0",
@@ -1795,6 +2352,33 @@
       "version": "1.6.1",
       "resolved": "http://r.npm.sankuai.com/repeat-string/download/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "request": {
+      "version": "2.82.0",
+      "resolved": "http://r.npm.sankuai.com/request/download/request-2.82.0.tgz",
+      "integrity": "sha1-K6ipLNesRWYOorEKU65nzSR1Fuo=",
+      "dependencies": {
+        "mime-db": {
+          "version": "1.30.0",
+          "resolved": "http://r.npm.sankuai.com/mime-db/download/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "http://r.npm.sankuai.com/mime-types/download/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "http://r.npm.sankuai.com/qs/download/qs-6.5.1.tgz",
+          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "http://r.npm.sankuai.com/safe-buffer/download/safe-buffer-5.1.1.tgz",
+          "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+        }
+      }
     },
     "request-sync-win": {
       "version": "0.0.2",
@@ -1881,6 +2465,11 @@
         }
       }
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/requires-port/download/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
     "ret": {
       "version": "0.1.14",
       "resolved": "http://r.npm.sankuai.com/ret/download/ret-0.1.14.tgz",
@@ -1890,6 +2479,33 @@
       "version": "5.0.1",
       "resolved": "http://r.npm.sankuai.com/safe-buffer/download/safe-buffer-5.0.1.tgz",
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+    },
+    "send": {
+      "version": "0.15.4",
+      "resolved": "http://r.npm.sankuai.com/send/download/send-0.15.4.tgz",
+      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "http://r.npm.sankuai.com/debug/download/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+        },
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "http://r.npm.sankuai.com/depd/download/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "http://r.npm.sankuai.com/http-errors/download/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.12.4",
+      "resolved": "http://r.npm.sankuai.com/serve-static/download/serve-static-1.12.4.tgz",
+      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -1901,10 +2517,27 @@
       "resolved": "http://r.npm.sankuai.com/setprototypeof/download/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
+    "sntp": {
+      "version": "2.0.2",
+      "resolved": "http://r.npm.sankuai.com/sntp/download/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "http://r.npm.sankuai.com/hoek/download/hoek-4.2.0.tgz",
+          "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "http://r.npm.sankuai.com/sprintf-js/download/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "http://r.npm.sankuai.com/sshpk/download/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M="
     },
     "statuses": {
       "version": "1.3.1",
@@ -1920,6 +2553,38 @@
       "version": "1.0.2",
       "resolved": "http://r.npm.sankuai.com/string_decoder/download/string_decoder-1.0.2.tgz",
       "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "http://r.npm.sankuai.com/stringstream/download/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "superagent": {
+      "version": "3.6.0",
+      "resolved": "http://r.npm.sankuai.com/superagent/download/superagent-3.6.0.tgz",
+      "integrity": "sha1-62eWUQV8NGIZnHuQK2lsJTUOG4c=",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "http://r.npm.sankuai.com/debug/download/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+        },
+        "mime": {
+          "version": "1.4.0",
+          "resolved": "http://r.npm.sankuai.com/mime/download/mime-1.4.0.tgz",
+          "integrity": "sha1-aeng21HUTyo7VuSLeBfX0Tfxo0M="
+        }
+      }
+    },
+    "supertest": {
+      "version": "3.0.0",
+      "resolved": "http://r.npm.sankuai.com/supertest/download/supertest-3.0.0.tgz",
+      "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY="
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "http://r.npm.sankuai.com/supports-color/download/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU="
     },
     "swagger-express-middleware-with-chance": {
       "version": "1.1.3",
@@ -1938,6 +2603,16 @@
         }
       }
     },
+    "swagger-jsblade-json-schema-ref-parser": {
+      "version": "3.1.2",
+      "resolved": "http://r.npm.sankuai.com/swagger-jsblade-json-schema-ref-parser/download/swagger-jsblade-json-schema-ref-parser-3.1.2.tgz",
+      "integrity": "sha1-jT12fVNsfed8Q3B/wcKlcqwn+tw="
+    },
+    "swagger-jsblade-swagger-parser": {
+      "version": "4.0.0-beta.2",
+      "resolved": "http://r.npm.sankuai.com/swagger-jsblade-swagger-parser/download/swagger-jsblade-swagger-parser-4.0.0-beta.2.tgz",
+      "integrity": "sha1-fpbno0X7zC1Cqsk2tI/FAb8hqHw="
+    },
     "swagger-methods": {
       "version": "1.0.0",
       "resolved": "http://r.npm.sankuai.com/swagger-methods/download/swagger-methods-1.0.0.tgz",
@@ -1948,13 +2623,44 @@
       "resolved": "http://r.npm.sankuai.com/swagger-mock-file-generator/download/swagger-mock-file-generator-1.1.1.tgz",
       "integrity": "sha1-9KQnafmylVtcKH3afa9h88zD2k4="
     },
+    "swagger-mock-file-generator-by-cases": {
+      "version": "1.0.8",
+      "resolved": "http://r.npm.sankuai.com/swagger-mock-file-generator-by-cases/download/swagger-mock-file-generator-by-cases-1.0.8.tgz",
+      "integrity": "sha1-DXpfEtjUOR0/Ed2wI4yQEJEvuNA=",
+      "dependencies": {
+        "swagger-mock-parser": {
+          "version": "1.1.14",
+          "resolved": "http://r.npm.sankuai.com/swagger-mock-parser/download/swagger-mock-parser-1.1.14.tgz",
+          "integrity": "sha1-E/MfLcfokBdhsgiyAMhVM6RVcJ0="
+        }
+      }
+    },
     "swagger-mock-parser": {
       "version": "1.1.8",
       "resolved": "http://r.npm.sankuai.com/swagger-mock-parser/download/swagger-mock-parser-1.1.8.tgz",
       "integrity": "sha1-JgcKgJhpjvz3joxFaKQtY4Sx9GY="
     },
     "swagger-parser": {
-      "version": "git://github.com/whq731/swagger-parser.git#45fe6b36a2a1043efc94725e8fc2d72f6c76044e"
+      "version": "3.4.2",
+      "resolved": "http://r.npm.sankuai.com/swagger-parser/download/swagger-parser-3.4.2.tgz",
+      "integrity": "sha1-JE1n1u7tCMAKy12VlQ1a771hhaM=",
+      "dependencies": {
+        "debug": {
+          "version": "3.0.1",
+          "resolved": "http://r.npm.sankuai.com/debug/download/debug-3.0.1.tgz",
+          "integrity": "sha1-BWTGErUh3JLZ8piPBUnjT5yY22Q="
+        },
+        "es6-promise": {
+          "version": "4.1.1",
+          "resolved": "http://r.npm.sankuai.com/es6-promise/download/es6-promise-4.1.1.tgz",
+          "integrity": "sha1-iBHpCRXZoNujYnTwskLb2nj5ySo="
+        },
+        "ono": {
+          "version": "4.0.2",
+          "resolved": "http://r.npm.sankuai.com/ono/download/ono-4.0.2.tgz",
+          "integrity": "sha1-Lhj/fCG56sDKt5T3owglBwANbTY="
+        }
+      }
     },
     "swagger-schema-official": {
       "version": "2.0.0-bab6bed",
@@ -1966,10 +2672,31 @@
       "resolved": "http://r.npm.sankuai.com/tmp/download/tmp-0.0.27.tgz",
       "integrity": "sha1-aq9CotdmQVCrUoKHBo7LwnE5oBM="
     },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "http://r.npm.sankuai.com/tough-cookie/download/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "http://r.npm.sankuai.com/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+    },
     "tv4": {
       "version": "1.3.0",
       "resolved": "http://r.npm.sankuai.com/tv4/download/tv4-1.3.0.tgz",
       "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "http://r.npm.sankuai.com/tweetnacl/download/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "http://r.npm.sankuai.com/type-detect/download/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
     },
     "type-is": {
       "version": "1.6.15",
@@ -1977,8 +2704,9 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
     },
     "universalify": {
-      "version": "http://r.npm.sankuai.com/universalify/download/universalify-0.1.0.tgz",
-      "integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g="
+      "version": "0.1.1",
+      "resolved": "http://r.npm.sankuai.com/universalify/download/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -1990,15 +2718,40 @@
       "resolved": "http://r.npm.sankuai.com/util-deprecate/download/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "http://r.npm.sankuai.com/utils-merge/download/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "http://r.npm.sankuai.com/uuid/download/uuid-3.1.0.tgz",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+    },
     "validator": {
-      "version": "6.3.0",
-      "resolved": "http://r.npm.sankuai.com/validator/download/validator-6.3.0.tgz",
-      "integrity": "sha1-R84j7Y1Ord+p1LjvAHG2zxB418g="
+      "version": "8.2.0",
+      "resolved": "http://r.npm.sankuai.com/validator/download/validator-8.2.0.tgz",
+      "integrity": "sha1-PBI3KQ43CSNVNE/veMIxJJ2rd7k="
+    },
+    "vary": {
+      "version": "1.1.1",
+      "resolved": "http://r.npm.sankuai.com/vary/download/vary-1.1.1.tgz",
+      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "http://r.npm.sankuai.com/verror/download/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://r.npm.sankuai.com/wrappy/download/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "z-schema": {
-      "version": "3.18.2",
-      "resolved": "http://r.npm.sankuai.com/z-schema/download/z-schema-3.18.2.tgz",
-      "integrity": "sha1-5CIZa17+YLRq3vPD8q7y3qqREWE="
+      "version": "3.18.4",
+      "resolved": "http://r.npm.sankuai.com/z-schema/download/z-schema-3.18.4.tgz",
+      "integrity": "sha1-6oEysnlTPuYL4khaAvfj5CVBqaI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   },
   "bin": {
     "blade": "bin/blade.js"
+  },
+  "devDependencies": {
+    "iron-node": "^3.0.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "request-sync-win": "0.0.2",
     "swagger-express-middleware-with-chance": "^1.1.3",
     "swagger-mock-file-generator": "^1.1.1",
-    "swagger-mock-file-generator-by-cases": "^1.0.8",
+    "swagger-mock-file-generator-by-cases": "^2.0.0",
     "swagger-parser": "^3.4.2",
     "universalify": "^0.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fs-extra": "^0.30.0",
     "fs-finder": "^1.8.1",
     "inquirer": "^1.0.2",
+    "jsonfile": "^4.0.0",
     "juicer-express-adapter": "^0.1.10",
     "lodash": "^4.13.1",
     "node-find-files": "0.0.4",
@@ -35,7 +36,9 @@
     "request-sync-win": "0.0.2",
     "swagger-express-middleware-with-chance": "^1.1.3",
     "swagger-mock-file-generator": "^1.1.1",
-    "swagger-mock-file-generator-by-cases": "^1.2.0"
+    "swagger-mock-file-generator-by-cases": "^1.0.8",
+    "swagger-parser": "^3.4.2",
+    "universalify": "^0.1.1"
   },
   "bin": {
     "blade": "bin/blade.js"


### PR DESCRIPTION
***[需求点这里](https://wiki.sankuai.com/display/TRAVEL/mock2.3)***
- 支持通过 -i/-include 传入要合并生成到 `mock.config.js` 中的 swagger 文件列表，以 `英文逗号` 分隔，如 `blade mock ./a.swagger.json -s 8893 -i ./b.swagger.json,.c.swagger.json`
- 扩充[config 文件增量更新的功能](https://github.com/lincolnlau/swagger-jsblade/pull/14)，将记录到的新增定义以及合并传入的 swagger 文件定义一并增量更新到配置文件，并在控制台输出本次增量更新的接口定义列表
- 升级[swagger-mock-file-generator-by-cases](https://github.com/MechanicianW/swagger-mock-file-generator-by-cases)的版本到2.0.0，以支持为多文件生成 Mock 数据
- 一并在依赖里添加了 iron-node，便于调试

——————
需回归测试原有的单文件传入流程
已自测的功能点有：
- [x] 多文件生成配置文件与JSON
- [x] 未查找到配置文件的情况下自动生成 mock.config.js
- [x] 单文件生成配置文件与JSON，接口定义改动后的增量更新流程
- [x] `swagger-mock-file-generator-by-cases@2.0.0`兼容了旧的单文件传参